### PR TITLE
Controlled-lossy compression

### DIFF
--- a/jpegls-filter.h
+++ b/jpegls-filter.h
@@ -58,15 +58,17 @@ struct subchunk_config_t {
     size_t lblocks = 1;
     size_t header_size = sizeof(uint32_t);
     size_t remainder = 0;
+    size_t lossy = 0;
 
-    constexpr subchunk_config_t(int l, size_t nblocks, size_t t)
+    constexpr subchunk_config_t(int l, size_t _nblocks, size_t t, int _lossy = 0)
         : length(l),
           typesize(t),
-          nblocks(nblocks),
+          nblocks(_nblocks),
           subchunks(std::min(size_t(24), nblocks)),
           lblocks(nblocks / subchunks),
           header_size(sizeof(uint32_t) * subchunks),
-          remainder(nblocks - lblocks * subchunks) {}
+          remainder(nblocks - lblocks * subchunks),
+          lossy(_lossy) {}
 };
 
 /** Compress one chunk of data, defined by the HDF5 chunk shape.


### PR DESCRIPTION
This add one more HDF5 compression option `lossy=int:0-65536`, to allow the controlled lossy compression option available in the CharLS codec. 

Background: Controlled lossy compression guarantees that the maximum absolute error is always bounded by the user-specified value (`abs(decoded value - encoded value) <= threshold`). This is distinct to conventional lossy compression codec (e.g. JPEG), where the upper bound is not known at compression time.

Target usecases:
1. encoding attitude 2D dataset,
2. encoding sensor-noise limited image, where the noise level is known at encoding time.