### PR TITLE
Implement encoder logic in a separate cpp file

### DIFF
--- a/examples/meson.build
+++ b/examples/meson.build
@@ -1,0 +1,18 @@
+highfive_dep = subproject('highfive').get_variable('highfive_dep')
+
+sync_write_exe = executable('sync_write',
+    sources: [
+        'sync-write.cpp',
+    ],
+    dependencies: [
+        highfive_dep,
+    ],
+)
+
+test('Write using dynamic plugin',
+    sync_write_exe,
+    env: {
+        'HDF5_PLUGIN_PATH': meson.current_build_dir() / '..',
+    },
+    suite: 'unittest',
+)

--- a/examples/sync-write.cpp
+++ b/examples/sync-write.cpp
@@ -1,0 +1,63 @@
+#include <cstdint>
+#include <iostream>
+#include <vector>
+
+#include <highfive/H5Exception.hpp>
+#include <highfive/H5File.hpp>
+#include <highfive/H5Object.hpp>
+#include <highfive/H5PropertyList.hpp>
+
+using HighFive::Chunking;
+using HighFive::DataSetCreateProps;
+using HighFive::DataSpace;
+using HighFive::File;
+
+namespace {
+
+class Jpegls {
+   public:
+    explicit Jpegls() = default;
+
+   private:
+    const std::array<uint32_t, 3> filter_param{0, 0, 0};
+    friend HighFive::DataSetCreateProps;
+    friend HighFive::GroupCreateProps;
+
+    inline void apply(const hid_t hid) const {
+        const auto status =
+            H5Pset_filter(hid, 32012, H5Z_FLAG_MANDATORY, filter_param.size(), filter_param.data());
+
+        if (status < 0) {
+            HighFive::HDF5ErrMapper::ToException<HighFive::PropertyException>(
+                "Error enabling Jpeg-LS filter");
+        }
+    }
+};
+
+}  // namespace
+
+int
+main() {
+    // Open a file
+    File file("sync-write.h5", File::Overwrite);
+
+    // Create DataSet
+    constexpr int height = 512;
+    constexpr int width = 512;
+    constexpr int chunk_height = 64;
+
+    auto props = DataSetCreateProps::Default();
+    props.add(Chunking{chunk_height, width});
+    props.add(Jpegls{});
+
+    auto dset = file.createDataSet<uint16_t>("/dset1", DataSpace{height, width}, props);
+
+    {
+        const std::vector<uint16_t> ones(height * width, 1);
+
+        // Write ones
+        dset.write_raw(ones.data());
+    }
+
+    return 0;
+}

--- a/h5jpegls.cpp
+++ b/h5jpegls.cpp
@@ -127,6 +127,7 @@ codec_filter(unsigned int flags, size_t cd_nelmts, const unsigned int cd_values[
         /* Compressing raw data into jpegls-encoding */
 
         jpegls::span<uint8_t> raw_data{reinterpret_cast<uint8_t*>(*buf), *buf_size};
+
         const auto out_buf = jpegls::encode(raw_data, config);
         *buf = out_buf.data;
         *buf_size = out_buf.size;

--- a/h5jpegls.cpp
+++ b/h5jpegls.cpp
@@ -25,6 +25,8 @@ ThreadPool* filter_pool = nullptr;
 
 using std::vector;
 
+#define VISIBLE __attribute__ ((visibility ("default")))
+
 namespace {
 
 // Temporary unofficial filter ID
@@ -45,6 +47,7 @@ getParams(const size_t cd_nelmts, const unsigned int cd_values[]) {
 
 }  // namespace
 
+VISIBLE
 size_t
 codec_filter(unsigned int flags, size_t cd_nelmts, const unsigned int cd_values[], size_t nbytes,
              size_t* buf_size, void** buf) {
@@ -136,6 +139,7 @@ codec_filter(unsigned int flags, size_t cd_nelmts, const unsigned int cd_values[
     }
 }
 
+VISIBLE
 herr_t h5jpegls_set_local(hid_t dcpl, hid_t type, hid_t) {  // NOLINT
     const auto [r, flags,
                 values] = [&]() -> std::tuple<herr_t, unsigned int, std::vector<unsigned int>> {
@@ -209,6 +213,7 @@ herr_t h5jpegls_set_local(hid_t dcpl, hid_t type, hid_t) {  // NOLINT
     return 1;
 }
 
+VISIBLE
 const H5Z_class2_t H5Z_JPEGLS[1] = {{
     H5Z_CLASS_T_VERS,                                      /* H5Z_class_t version */
     H5Z_FILTER_JPEGLS,                                     /* Filter id number */
@@ -220,9 +225,12 @@ const H5Z_class2_t H5Z_JPEGLS[1] = {{
     static_cast<H5Z_func_t>(codec_filter),                 /* The actual filter function */
 }};
 
+VISIBLE
 H5PL_type_t H5PLget_plugin_type() {  // NOLINT
     return H5PL_TYPE_FILTER;
 }
+
+VISIBLE
 const void* H5PLget_plugin_info() {  // NOLINT
     return H5Z_JPEGLS;
 }

--- a/jpegls-filter.cpp
+++ b/jpegls-filter.cpp
@@ -1,0 +1,114 @@
+#include "jpegls-filter.h"
+
+#include <numeric>
+#include <iostream>
+
+#include "charls/charls.h"
+
+using byte_array_t = std::vector<uint8_t>;
+
+namespace {
+
+template <typename T>
+struct image_buffer_t {
+    jpegls::span<T> buffer;
+
+    size_t typesize = 1;
+    /** Pixel width. */
+    size_t width = 0;
+
+    /** Image height, i.e. number of pixel width. */
+    size_t height = 0;
+
+    /** Number of interleaved samples in a pixel. */
+    uint32_t channels = 1;
+};
+
+/** Given one subchunk of data, compress it and return the encoded data. */
+template <typename T>
+byte_array_t
+encodeSubchunk(const image_buffer_t<T> raw) {
+    const auto reserved_size = raw.buffer.size_bytes();
+    byte_array_t encoded(reserved_size + 8192);
+
+    auto params = [&]() -> const JlsParameters {
+        auto params = JlsParameters();
+        params.width = raw.width;
+        params.height = raw.height;
+        params.bitsPerSample = raw.typesize * 8;
+        params.components = raw.channels;
+        return params;
+    }();
+
+    size_t csize;
+    char err_msg[256];
+    const CharlsApiResultType ret = JpegLsEncode(
+        encoded.data(), encoded.size(), &csize,
+        raw.buffer.begin(),
+        raw.buffer.size_bytes(), &params, err_msg);
+    if (ret != CharlsApiResultType::OK) {
+        std::cerr << "JPEG-LS error: " << err_msg << '\n';
+    }
+
+    encoded.resize(csize);
+
+    return encoded;
+}
+
+}
+
+namespace jpegls {
+
+int
+encode(span<uint8_t> raw, const subchunk_config_t c) {
+    std::vector<uint32_t> block_size(c.subchunks);
+    std::vector<byte_array_t> local_out(c.subchunks);
+
+    // For each sub-chunk of raw data, determine the byte range, image width and height.
+    // Then, compress data.
+#pragma omp parallel for schedule(guided)
+    for (size_t block = 0; block < c.subchunks; block++) {
+        const size_t width = c.length;
+        const size_t height = (c.remainder != 0 && block == c.subchunks) ? c.remainder : c.lblocks;
+        const size_t offset = c.typesize * width * height * block;
+
+        const image_buffer_t<const uint8_t> input{raw.subspan(offset, width * height * c.typesize),
+                                                  c.typesize, width, height, 1};
+
+        local_out[block] = encodeSubchunk(input);
+    }
+
+    // Compute the total compressed size in bytes.
+    const auto compressed_size =
+        std::accumulate(local_out.begin(), local_out.end(), c.header_size,
+                        [](const auto& a, const auto& b) -> size_t { return a + b.size(); });
+
+    // Reallocate the raw buffer, if the new size is larger than original size.
+    span<uint8_t> out_buf;
+
+    if (compressed_size <= raw.size) {
+        out_buf = raw;
+    } else {
+        out_buf = {static_cast<uint8_t*>(realloc(raw.data, compressed_size)), compressed_size};
+    }
+
+    span<uint32_t> header{reinterpret_cast<uint32_t*>(out_buf.data), c.subchunks};
+
+#pragma omp parallel for schedule(guided)
+    for (size_t block = 0; block < c.subchunks; block++) {
+        const auto offset = std::accumulate(
+            local_out.begin(), local_out.begin() + block, c.header_size,
+            [](const auto& a, const auto& b) -> size_t { return a + b.size(); });
+
+        const auto& local_buf = local_out[block];
+
+        // Write header
+        header[block] = local_buf.size();
+
+        // Write payload
+        std::copy(local_buf.begin(), local_buf.end(), raw.begin() + offset);
+    }
+
+    return compressed_size;
+}
+}

--- a/jpegls-filter.h
+++ b/jpegls-filter.h
@@ -1,0 +1,72 @@
+#pragma once
+#include <cstdint>
+#include <vector>
+
+namespace jpegls {
+
+using std::size_t;
+
+/** Lightweight implementation of std::span<uint8_t>. */
+template<typename T>
+struct span {
+    T* data = nullptr;
+    size_t size = 0;
+
+    constexpr T* begin() const {
+        return data;
+    }
+
+    constexpr T* end() const {
+        return data + size;
+    }
+
+    constexpr T& operator[](const size_t i) const {
+        return data[i];
+    }
+
+    constexpr size_t size_bytes() const {
+        return size * sizeof(T);
+    }
+
+    constexpr span<T> subspan(size_t offset, size_t expected_length) const {
+        if(offset > size) {
+            return {};
+        }
+
+        if (offset + expected_length > size) {
+            return {data + offset, size - offset};
+        }
+
+        return {data + offset, expected_length};
+    }
+
+    constexpr operator span<const uint8_t>() const {
+        return {reinterpret_cast<const uint8_t*>(data), size * sizeof(uint8_t)};
+    }
+};
+
+struct subchunk_config_t {
+    size_t length = 1;
+    size_t typesize = 1;
+    size_t subchunks = 1;
+    size_t lblocks = 1;
+    size_t header_size = sizeof(uint32_t);
+    size_t remainder = 0;
+
+    constexpr subchunk_config_t(int l, size_t nblocks, size_t t)
+        : length(l),
+          typesize(t),
+          subchunks(std::min(size_t(24), nblocks)),
+          lblocks(nblocks / subchunks),
+          header_size(sizeof(uint32_t) * subchunks),
+          remainder(nblocks - lblocks * subchunks) {}
+};
+/** Compress one chunk of data, defined by the HDF5 chunk shape.
+ * @param[in] raw input data pointer and byte count.
+ * @param[in] config sub-chunk data layout to compress in parallel.
+ * @param[out] encoded encoded data.
+ */
+int
+encode(span<uint8_t> buffer, const subchunk_config_t config);
+
+}

--- a/jpegls-filter.h
+++ b/jpegls-filter.h
@@ -66,7 +66,7 @@ struct subchunk_config_t {
  * @param[in] config sub-chunk data layout to compress in parallel.
  * @param[out] encoded encoded data.
  */
-int
+span<uint8_t>
 encode(span<uint8_t> buffer, const subchunk_config_t config);
 
 }

--- a/meson.build
+++ b/meson.build
@@ -27,6 +27,7 @@ h5jpegls_lib = library('h5jpegls',
         charls_inc,
     ],
     cpp_args: [
+        '-fvisibility=hidden',
         '-DNO_DEBUG',
     ],
     link_with: [

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,7 @@
 project('jpegls-hdf-filter', 'cpp',
     version: '0.1',
     license: 'MIT',
+    meson_version: '>=0.57',
     default_options : [
         'buildtype=debugoptimized',
         'b_ndebug=if-release',
@@ -20,6 +21,7 @@ openmp_dep = dependency('openmp')
 h5jpegls_lib = library('h5jpegls',
     sources: [
         'h5jpegls.cpp',
+        'jpegls-filter.cpp',
     ],
     include_directories: [
         charls_inc,

--- a/meson.build
+++ b/meson.build
@@ -95,3 +95,5 @@ test('JPEG-LS decoding w/ h5repack',
         restored_data,
     ],
 )
+
+subdir('examples')

--- a/subprojects/highfive.wrap
+++ b/subprojects/highfive.wrap
@@ -1,0 +1,5 @@
+[wrap-git]
+url = https://github.com/BlueBrain/HighFive.git
+revision = v2.4.1
+
+patch_directory = highfive

--- a/subprojects/packagefiles/highfive/meson.build
+++ b/subprojects/packagefiles/highfive/meson.build
@@ -1,0 +1,39 @@
+project('highfive', 'cpp',
+    version: 'v1.10.4-6',
+)
+
+# Header-only library
+highfive_inc = include_directories('include')
+
+# highfive is a high-level abstraction of the
+# C-functions in the libhdf5 library 
+highfive_dep = declare_dependency(
+    include_directories: highfive_inc,
+    dependencies: [
+        dependency('hdf5-serial'),
+    ]
+)
+
+read_write_vector_exe = executable(
+    'read_write_vector',
+    sources: 'src/examples/read_write_vector_dataset.cpp',
+    dependencies: highfive_dep,
+)
+
+read_write_partial_exe = executable(
+    'select_partial_dataset_cpp11',
+    sources: 'src/examples/select_partial_dataset_cpp11.cpp',
+    dependencies: highfive_dep,
+)
+
+# Test the highfive APIs
+
+test('read and write vector',
+    read_write_vector_exe,
+    suite: 'highfive',
+)
+
+test('read only a few pixels',
+    read_write_partial_exe,
+    suite: 'highfive',
+)


### PR DESCRIPTION
Define struct `subchunk_config_t` to compute subchunks sizes for
compression and decoding. Use the subchunk_config_t parameters to
determine whether if subchunk size is smaller than the remaining
rows/heights of data.

Const the chunk buffer data pointer (i.e. `const uint8_t`) whenever
possible to prevent new bugs.

Added an example app `sync-write.cpp` to write pixels with `libhdf5` C APIs; read back the pixels to validate the jpegls filter. I is not yet a thorough data validation because only one set of values (all `1`'s) are tested.