### PR TITLE
Expose the compression function for direct chunk write

### DIFF
--- a/examples/direct_chunk_write.cpp
+++ b/examples/direct_chunk_write.cpp
@@ -1,0 +1,145 @@
+#include <cstdint>
+#include <iostream>
+#include <vector>
+
+#include <highfive/H5Exception.hpp>
+#include <highfive/H5File.hpp>
+#include <highfive/H5Object.hpp>
+#include <highfive/H5PropertyList.hpp>
+
+#if H5_VERSION_LE(1, 10, 2)
+#include <hdf5_hl.h>
+#endif
+
+#include "jpegls-filter.h"
+
+using HighFive::Chunking;
+using HighFive::DataSetCreateProps;
+using HighFive::DataSpace;
+using HighFive::File;
+
+namespace {
+
+class TaskflowTimeProfiler {
+    std::shared_ptr<tf::ChromeObserver> observer;
+
+   public:
+    /** Create the default observer */
+    TaskflowTimeProfiler(tf::Executor* executor)
+        : observer((executor) ? executor->make_observer<tf::ChromeObserver>() : nullptr) {}
+
+    /** When this object goes out of scope, dump the time profiling data
+     * to the system `/tmp` folder.
+     */
+    ~TaskflowTimeProfiler() {
+        if (observer == nullptr) {
+            return;
+        }
+
+        std::cout << "Exporting time profiling data...\n";
+
+        std::ofstream tracing_file("/tmp/tracing.json", std::ofstream::trunc);
+
+        // dump the execution timeline to json (view at chrome://tracing)
+        observer->dump(tracing_file);
+
+        tracing_file.close();
+    }
+};
+
+class Jpegls {
+   public:
+    explicit Jpegls() = default;
+
+   private:
+    const std::array<uint32_t, 3> filter_param{0, 0, 0};
+    friend HighFive::DataSetCreateProps;
+    friend HighFive::GroupCreateProps;
+
+    inline void apply(const hid_t hid) const {
+        const auto status =
+            H5Pset_filter(hid, 32012, H5Z_FLAG_MANDATORY, filter_param.size(), filter_param.data());
+
+        if (status < 0) {
+            HighFive::HDF5ErrMapper::ToException<HighFive::PropertyException>(
+                "Error enabling Jpeg-LS filter");
+        }
+    }
+};
+
+template <class Dataset, typename T>
+herr_t
+writeChunk(Dataset& dset, const std::array<hsize_t, 2> offset, std::vector<T>&& src_buffer) {
+    const auto dset_id = dset.getId();
+    constexpr auto filter_mask = 0;
+
+#if H5_VERSION_LE(1, 10, 2)
+    return H5DOwrite_chunk(dset_id, H5P_DEFAULT, filter_mask, offset.data(), src_buffer.size(),
+                           src_buffer.data());
+#else
+    return H5Dwrite_chunk(dset_id, H5P_DEFAULT, filter_mask, offset.data(), src_buffer.size(),
+                          src_buffer.data());
+#endif
+}
+
+}  // namespace
+
+int
+main() {
+    // Open a file
+    File file("testing.h5", File::Overwrite);
+
+    // Create DataSet
+    constexpr int height = 512;
+    constexpr int width = 512;
+    constexpr int chunk_height = 64;
+
+    auto props = DataSetCreateProps::Default();
+    props.add(Chunking{chunk_height, width});
+    props.add(Jpegls{});
+
+    auto dset = file.createDataSet<uint16_t>("/dset1", DataSpace{height, width}, props);
+
+    {
+        const std::vector<uint16_t> ones(height * width, 1);
+
+        // Write ones
+        dset.write_raw(ones.data());
+    }
+
+    // Allocate memory
+    tf::Taskflow taskflow;
+    jpegls::encode_ctx_t encoded;
+    const jpegls::subchunk_config_t config(width, chunk_height, sizeof(uint16_t));
+
+    const std::vector<uint16_t> twos(chunk_height * width, 2);
+
+    auto [A, B, C] =
+        encodeAsync(jpegls::span<const uint8_t>{reinterpret_cast<const uint8_t*>(twos.data()),
+                                                twos.size() * sizeof(uint16_t)},
+                    config, taskflow, encoded);
+
+    auto write_task = taskflow
+                          .emplace([&]() {
+                              const auto status = writeChunk(
+                                  dset, {0, 0}, std::move(std::get<jpegls::byte_array_t>(encoded)));
+                              if (status < 0) {
+                                  std::cerr << "Error: " << status << '\n';
+                              }
+                          })
+                          .name("Write");
+
+    // Now, schedule the tasks
+    C.precede(write_task);
+
+    // Now execute all tasks in multi-threaded environment
+    tf::Executor executor;
+
+    // (Optional) Profile the time spent on each task
+    constexpr bool export_benchmark = true;
+    TaskflowTimeProfiler profiler((export_benchmark) ? &executor : nullptr);
+
+    executor.run(taskflow).wait();
+
+    return 0;
+}

--- a/examples/meson.build
+++ b/examples/meson.build
@@ -1,5 +1,8 @@
 highfive_dep = subproject('highfive').get_variable('highfive_dep')
 
+cxx = meson.get_compiler('cpp')
+hdf5_hl_lib = cxx.find_library('hdf5_hl', dirs: '/usr/lib/x86_64-linux-gnu/hdf5/serial')
+
 sync_write_exe = executable('sync_write',
     sources: [
         'sync-write.cpp',
@@ -9,10 +12,30 @@ sync_write_exe = executable('sync_write',
     ],
 )
 
+direct_chunk_write_exe = executable('direct_chunk_write',
+    sources: [
+        'direct_chunk_write.cpp',
+    ],
+    dependencies: [
+        highfive_dep,
+        jpegls_filter_async_dep,
+        hdf5_hl_lib,
+    ],
+)
+
 test('Write using dynamic plugin',
     sync_write_exe,
     env: {
         'HDF5_PLUGIN_PATH': meson.current_build_dir() / '..',
     },
     suite: 'unittest',
+)
+
+test('Writing small chunks',
+    direct_chunk_write_exe,
+    env: {
+        'HDF5_PLUGIN_PATH': meson.current_build_dir() / '..',
+    },
+    suite: 'unittest',
+    is_parallel: false,
 )

--- a/h5jpegls.cpp
+++ b/h5jpegls.cpp
@@ -130,7 +130,6 @@ codec_filter(unsigned int flags, size_t cd_nelmts, const unsigned int cd_values[
         /* Compressing raw data into jpegls-encoding */
 
         jpegls::span<uint8_t> raw_data{reinterpret_cast<uint8_t*>(*buf), *buf_size};
-
         const auto out_buf = jpegls::encode(raw_data, config);
         *buf = out_buf.data;
         *buf_size = out_buf.size;

--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,4 @@
-project('jpegls-hdf-filter', 'cpp',
+project('jpegls-hdf-filter', 'cpp', 'c',
     version: '0.1',
     license: 'MIT',
     meson_version: '>=0.57',
@@ -14,14 +14,39 @@ charls_proj = subproject('charls',
 charls_lib = charls_proj.get_variable('charls_lib')
 charls_inc = charls_proj.get_variable('charls_inc')
 
-hdf5_dep = dependency('hdf5-serial')
+hdf5_dep = dependency('hdf5', language: 'c')
 threads_dep = dependency('threads')
 openmp_dep = dependency('openmp')
+taskflow_dep = subproject('taskflow').get_variable('taskflow_dep')
+
+jpegls_filter_dep = declare_dependency(
+    include_directories: [
+        '.',
+        charls_inc,
+    ],
+    sources: [
+        'jpegls-filter.cpp',
+    ],
+    link_with: [
+        charls_lib,
+    ],
+    dependencies: [
+        threads_dep,
+        openmp_dep,
+    ],
+)
+
+jpegls_filter_async_dep = declare_dependency(
+    compile_args: '-DH5JPEGLS_USE_ASYNC',
+    dependencies: [
+        jpegls_filter_dep,
+        taskflow_dep,
+    ],
+)
 
 h5jpegls_lib = library('h5jpegls',
     sources: [
         'h5jpegls.cpp',
-        'jpegls-filter.cpp',
     ],
     include_directories: [
         charls_inc,
@@ -30,13 +55,10 @@ h5jpegls_lib = library('h5jpegls',
         '-fvisibility=hidden',
         '-DNO_DEBUG',
     ],
-    link_with: [
-        charls_lib,
-    ],
     dependencies: [
+        jpegls_filter_dep,
         hdf5_dep,
         threads_dep,
-        openmp_dep,
     ],
 )
 

--- a/subprojects/packagefiles/highfive/meson.build
+++ b/subprojects/packagefiles/highfive/meson.build
@@ -1,4 +1,4 @@
-project('highfive', 'cpp',
+project('highfive', 'cpp', 'c',
     version: 'v1.10.4-6',
 )
 
@@ -10,7 +10,7 @@ highfive_inc = include_directories('include')
 highfive_dep = declare_dependency(
     include_directories: highfive_inc,
     dependencies: [
-        dependency('hdf5-serial'),
+        dependency('hdf5', language: 'c'),
     ]
 )
 

--- a/subprojects/packagefiles/taskflow/meson.build
+++ b/subprojects/packagefiles/taskflow/meson.build
@@ -1,0 +1,13 @@
+project('taskflow', 'cpp',
+    version: 'v2.7.0',
+)
+
+# Header-only library
+taskflow_inc = include_directories('.')
+
+taskflow_dep = declare_dependency(
+    include_directories: taskflow_inc,
+    dependencies: [
+        dependency('threads'),
+    ]
+)

--- a/subprojects/taskflow.wrap
+++ b/subprojects/taskflow.wrap
@@ -1,0 +1,5 @@
+[wrap-git]
+url = https://github.com/taskflow/taskflow.git
+revision = 1376a36a26982cbcb4dfe5da399dd7771f0433a7
+
+patch_directory = taskflow


### PR DESCRIPTION
Implement the `jpegls::encodeAsync` function to receive a set of user-provided
raw data (uint8 or uint16) of exactly one chunk in size. Partition it up to 24
subchunks, then compress and encode the subchunks to the output buffer.

Enable the function only when the c-preprocessor flag `-DH5JPEGLS_USE_ASYNC`
is present in the compile command.

An example app `direct-chunk-write.cpp` is also provided to demonstrate
how compression can be executed asynchronously with the H5Dwrite_chunk
function.