### PR TITLE
Upgrade to Taskflow v3.4.0

### DIFF
--- a/subprojects/packagefiles/taskflow/3rd-party/doctest/meson.build
+++ b/subprojects/packagefiles/taskflow/3rd-party/doctest/meson.build
@@ -1,0 +1,4 @@
+# Author curated doctest header-only library
+doctest_dep = declare_dependency(
+    include_directories: '.',
+)

--- a/subprojects/packagefiles/taskflow/meson.build
+++ b/subprojects/packagefiles/taskflow/meson.build
@@ -1,5 +1,9 @@
 project('taskflow', 'cpp',
-    version: 'v2.7.0',
+    version: '3.4.0',
+    license: 'MIT',
+    default_options: [
+      'cpp_std=c++17',
+    ],
 )
 
 # Header-only library
@@ -11,3 +15,34 @@ taskflow_dep = declare_dependency(
         dependency('threads'),
     ]
 )
+
+# Provides the author selected doctest header-only library
+subdir('3rd-party/doctest')
+
+# TODO: Scan the system for external doctest dependency
+# Reference: https://github.com/doctest/doctest/issues/670
+#doctest_dep = dependency('doctest', required: false)
+
+# Unit tests
+if get_option('tests')
+subdir('unittests')
+endif
+
+# Installations
+
+# Copy all header files to ${prefix}/include/taskflow/
+install_subdir(
+    'taskflow',
+    install_dir: 'include',
+)
+
+# Generate pkgconfig
+pkgconfig = import('pkgconfig')
+pkgconfig.generate(
+    name: 'Taskflow',
+    description: 'A General-purpose Parallel and Heterogeneous Task Programming System',
+    url: 'https://taskflow.github.io/',
+    subdirs: 'taskflow',
+    libraries: dependency('threads'),
+)
+

--- a/subprojects/packagefiles/taskflow/meson_options.txt
+++ b/subprojects/packagefiles/taskflow/meson_options.txt
@@ -1,0 +1,1 @@
+option('tests', type: 'boolean', value: false)

--- a/subprojects/packagefiles/taskflow/unittests/meson.build
+++ b/subprojects/packagefiles/taskflow/unittests/meson.build
@@ -1,0 +1,43 @@
+if get_option('buildtype') == 'debug' or get_option('buildtype') == 'plain'
+warning('Unittests not effective when buildtype == debug or plain')
+endif
+
+unittest_list = [
+    #'utility',
+    'tsq',
+    #'serializer ',
+    'basics',
+    'asyncs',
+    'subflows',
+    'control_flow',
+    'semaphores',
+    'movable',
+    'cancellation',
+    'algorithms',
+    'compositions',
+    'traversals',
+    'sorting',
+    'pipelines',
+    'scalable_pipelines',
+    'runtimes',
+]
+
+foreach test_group : unittest_list
+
+tf_unittest_exe = executable(test_group,
+    sources: [
+        test_group + '.cpp',
+    ],
+    include_directories: '/usr/include/doctest',
+    dependencies: [
+        doctest_dep,
+        taskflow_dep,
+    ],
+)
+
+test(test_group,
+    tf_unittest_exe,
+    is_parallel: false,
+)
+
+endforeach

--- a/subprojects/taskflow.wrap
+++ b/subprojects/taskflow.wrap
@@ -1,5 +1,11 @@
-[wrap-git]
-url = https://github.com/taskflow/taskflow.git
-revision = 1376a36a26982cbcb4dfe5da399dd7771f0433a7
+[wrap-file]
+directory = taskflow-3.4.0
+
+source_url = https://github.com/taskflow/taskflow/archive/refs/tags/v3.4.0.tar.gz
+source_filename = taskflow-v3.4.0.tar.gz
+source_hash = 8f449137d3f642b43e905aeacdf1d7c5365037d5e1586103ed4f459f87cecf89
 
 patch_directory = taskflow
+
+[provide]
+taskflow = taskflow_dep


### PR DESCRIPTION
Upgrade the 3rd party project Taskflow to v3.4.0, in order to utilize
the Pipeflow library for the direct chunk write feature.