### PR TITLE
Do not search for high-level hdf5 library manually

### DIFF
--- a/examples/meson.build
+++ b/examples/meson.build
@@ -1,8 +1,5 @@
 highfive_dep = subproject('highfive').get_variable('highfive_dep')
 
-cxx = meson.get_compiler('cpp')
-hdf5_hl_lib = cxx.find_library('hdf5_hl', dirs: '/usr/lib/x86_64-linux-gnu/hdf5/serial')
-
 sync_write_exe = executable('sync_write',
     sources: [
         'sync-write.cpp',
@@ -19,7 +16,6 @@ direct_chunk_write_exe = executable('direct_chunk_write',
     dependencies: [
         highfive_dep,
         jpegls_filter_async_dep,
-        hdf5_hl_lib,
     ],
 )
 


### PR DESCRIPTION
The meson build system searches for the libhdf5_hl.so automatically in the system. Remove the manual search code.